### PR TITLE
Only commit changes under the specified output path

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -132,6 +132,7 @@ var RuntimeBenchmarkConfigs = {
             '--raw',
             '--execution=wasm',
             '--wasm-execution=compiled',
+            '--heap-pages 4096',
             '--output ./bin/node/runtime/src/weights',
             '--header ./HEADER',
             '--pallet',

--- a/bench.js
+++ b/bench.js
@@ -234,7 +234,9 @@ async function benchmarkRuntime(app, config) {
 
         // If `--output` is set, we commit the benchmark file to the repo
         if (output) {
-            benchContext.runTask(`git add .`, `Adding new files.`);
+            const regex = /--output(?:=|\s+)(".+?"|\S+)/;
+            const path = benchConfig.branchCommand.match(regex)[1];
+            benchContext.runTask(`git add ${path}`, `Adding new files.`);
             benchContext.runTask(`git commit -m "${benchConfig.branchCommand}"`, `Committing changes.`);
             if (config.pushToken) {
                 benchContext.runTask(`git push https://${config.pushToken}@github.com/paritytech/substrate.git HEAD`, `Pushing commit with pushToken.`);


### PR DESCRIPTION
This also adds `--heap-pages 4096` to the bench command to allow for bigger benchmark suites by default.